### PR TITLE
商品出品/表示のAPI作成

### DIFF
--- a/app/Http/Controllers/easymarket/API/ProductController.php
+++ b/app/Http/Controllers/easymarket/API/ProductController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\easymarket\API;
+
+use Illuminate\Support\Facades\Auth;
+use App\Exceptions\APIBusinessLogicException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\easymarket\API\Product\StoreRequest;
+use App\Http\Resources\easymarket\API\ProductResource;
+use App\Services\easymarket\ProductService\Dtos\StoreCommand;
+use App\Services\easymarket\ProductService\ProductServiceInterface;
+use App\Services\easymarket\ProductService\Exceptions\IncompleteSellerInfoException;
+
+class ProductController extends Controller
+{
+    /**
+    * @var ProductServiceInterface
+    */
+    private $productService;
+
+    /**
+     * @param  ProductServiceInterface  $productService
+     * @return void
+     */
+    public function __construct(
+        ProductServiceInterface $productService
+    )
+    {
+        $this->productService = $productService;
+    }
+
+    public function store(StoreRequest $request)
+    {
+        $params = $request->safe();
+        /** @var \App\Models\User $user */
+        $user = Auth::user();
+        $storeCommand = new StoreCommand(
+            $user,
+            $params['name'],
+            $params['description'],
+            $params['price'],
+            $params['images'],
+        );
+        try {
+            $product = $this->productService->store($storeCommand);
+        } catch (IncompleteSellerInfoException $e) {
+            throw new APIBusinessLogicException($e->getMessage(), 400);
+        }
+
+        return new ProductResource($product);
+    }
+
+}

--- a/app/Http/Controllers/easymarket/API/ProductController.php
+++ b/app/Http/Controllers/easymarket/API/ProductController.php
@@ -5,8 +5,10 @@ namespace App\Http\Controllers\easymarket\API;
 use Illuminate\Support\Facades\Auth;
 use App\Exceptions\APIBusinessLogicException;
 use App\Http\Controllers\Controller;
+use App\Models\Product;
 use App\Http\Requests\easymarket\API\Product\IndexRequest;
 use App\Http\Requests\easymarket\API\Product\StoreRequest;
+use App\Http\Requests\easymarket\API\Product\ShowRequest;
 use App\Http\Resources\easymarket\API\ProductResource;
 use App\Services\easymarket\ProductService\Dtos\StoreCommand;
 use App\Services\easymarket\ProductService\ProductServiceInterface;
@@ -68,6 +70,17 @@ class ProductController extends Controller
             throw new APIBusinessLogicException($e->getMessage(), 400);
         }
 
+        return new ProductResource($product);
+    }
+
+    /**
+     * 商品一覧取得API
+     * 
+     * @param  ShowRequest  $request
+     * @return ProductResource
+     */
+    public function show(ShowRequest $request, Product $product)
+    {
         return new ProductResource($product);
     }
 

--- a/app/Http/Controllers/easymarket/API/ProductController.php
+++ b/app/Http/Controllers/easymarket/API/ProductController.php
@@ -5,11 +5,13 @@ namespace App\Http\Controllers\easymarket\API;
 use Illuminate\Support\Facades\Auth;
 use App\Exceptions\APIBusinessLogicException;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\easymarket\API\Product\IndexRequest;
 use App\Http\Requests\easymarket\API\Product\StoreRequest;
 use App\Http\Resources\easymarket\API\ProductResource;
 use App\Services\easymarket\ProductService\Dtos\StoreCommand;
 use App\Services\easymarket\ProductService\ProductServiceInterface;
 use App\Services\easymarket\ProductService\Exceptions\IncompleteSellerInfoException;
+use App\Http\Resources\easymarket\API\ProductCollection;
 
 class ProductController extends Controller
 {
@@ -29,6 +31,25 @@ class ProductController extends Controller
         $this->productService = $productService;
     }
 
+    /**
+     * 商品一覧取得API
+     * 
+     * @param  IndexRequest  $request
+     * @return ProductCollection
+     */
+    public function index(IndexRequest $request)
+    {
+        $products = $this->productService->get();
+
+        return new ProductCollection($products);
+    }
+
+    /**
+     * 出品API
+     * 
+     * @param  StoreRequest  $request
+     * @return ProductResource
+     */
     public function store(StoreRequest $request)
     {
         $params = $request->safe();

--- a/app/Http/Requests/easymarket/API/Product/IndexRequest.php
+++ b/app/Http/Requests/easymarket/API/Product/IndexRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\Product;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/easymarket/API/Product/ShowRequest.php
+++ b/app/Http/Requests/easymarket/API/Product/ShowRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\Product;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/easymarket/API/Product/StoreRequest.php
+++ b/app/Http/Requests/easymarket/API/Product/StoreRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\Product;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'description' => 'required|string|max:1000',
+            'price' => 'required|integer|min:0',
+            'images' => 'required|array',
+            'images.*' => 'file|mimes:jpeg,png,jpg,gif,svg|max:2048',
+        ];
+    }
+
+    /**
+     * Get custom attributes for validator errors.
+     * 
+     * @return array<string, string>
+     */
+    public function attributes()
+    {
+        return [
+            'name' => '商品名',
+            'description' => '商品紹介文',
+            'price' => '金額',
+            'images' => '商品画像',
+            'images.*' => '商品画像',
+        ];
+    }
+}

--- a/app/Http/Resources/easymarket/API/DealResource.php
+++ b/app/Http/Resources/easymarket/API/DealResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources\easymarket\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Deal */
+class DealResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'is_purchasable' => $this->is_purchasable,
+            'seller_info' => new SellerInfoResource($this->seller),
+        ];
+    }
+}

--- a/app/Http/Resources/easymarket/API/ProductCollection.php
+++ b/app/Http/Resources/easymarket/API/ProductCollection.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources\easymarket\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ProductCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @return array<int|string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'products' => $this->collection,
+        ];
+    }
+}

--- a/app/Http/Resources/easymarket/API/ProductResource.php
+++ b/app/Http/Resources/easymarket/API/ProductResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources\easymarket\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Product */
+class ProductResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'image_url' => $this->present()->imageUrl(),
+            'image_urls' => $this->present()->imageUrls(),
+            'price' => $this->price,
+            'deal' => new DealResource($this->deal),
+        ];
+    }
+}

--- a/app/Http/Resources/easymarket/API/SellerInfoResource.php
+++ b/app/Http/Resources/easymarket/API/SellerInfoResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\easymarket\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\User */
+class SellerInfoResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'nickname' => $this->nickname,
+            'profile_image_url' => $this->present()->profileImageUrl,
+            'description' => $this->description,
+        ];
+    }
+}

--- a/app/Presenters/ProductPresenter.php
+++ b/app/Presenters/ProductPresenter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Presenters;
+
+use Laracasts\Presenter\Presenter;
+
+/** @mixin \App\Models\Product */
+class ProductPresenter extends Presenter
+{
+    public function imageUrl(): ?string
+    {
+        $urls = $this->imageUrls();
+
+        return $urls[0] ?? null;
+    }
+
+    public function imageUrls(): array
+    {
+        return $this->images->map(function ($image) {
+            /** @var \App\Models\Image $image */
+            return $image->present()->url();
+        })->toArray();
+    }
+}

--- a/app/Providers/ServiceeasymarketServiceProvider.php
+++ b/app/Providers/ServiceeasymarketServiceProvider.php
@@ -25,6 +25,10 @@ class ServiceeasymarketServiceProvider extends ServiceProvider
             \App\Services\easymarket\UserService\UserServiceInterface::class,
             \App\Services\easymarket\UserService\UserService::class
         );
+        $this->app->bind(
+            \App\Services\easymarket\ProductService\ProductServiceInterface::class,
+            \App\Services\easymarket\ProductService\ProductService::class
+        );
     }
 
     /**

--- a/app/Services/easymarket/ProductService/Dtos/StoreCommand.php
+++ b/app/Services/easymarket/ProductService/Dtos/StoreCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services\easymarket\ProductService\Dtos;
+
+use App\Models\User;
+
+class StoreCommand
+{
+    public User $seller;
+    public string $name;
+    public string $description;
+    public int $price;
+    /** @var \Illuminate\Http\UploadedFile[] */
+    public array $images;
+
+    /**
+     * @param User $seller
+     * @param string $name
+     * @param string $description
+     * @param int $price
+     * @param \Illuminate\Http\UploadedFile[] $images
+     */
+    public function __construct(
+        User $seller,
+        string $name,
+        string $description,
+        int $price,
+        array $images
+    )
+    {
+        $this->seller = $seller;
+        $this->name = $name;
+        $this->description = $description;
+        $this->price = $price;
+        $this->images = $images;
+    }
+}

--- a/app/Services/easymarket/ProductService/Exceptions/IncompleteSellerInfoException.php
+++ b/app/Services/easymarket/ProductService/Exceptions/IncompleteSellerInfoException.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Services\easymarket\ProductService\Exceptions;
+
+use Exception;
+
+class IncompleteSellerInfoException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('出品者情報が不足しています。');
+    }
+}

--- a/app/Services/easymarket/ProductService/ProductService.php
+++ b/app/Services/easymarket/ProductService/ProductService.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Services\easymarket\ProductService;
+
+use App\Enums\{DealEventActorType, DealEventEventType};
+use App\Models\{Deal, DealEvent, Product, User};
+use App\Services\easymarket\ProductService\Dtos\StoreCommand;
+use App\Services\easymarket\ProductService\Exceptions\IncompleteSellerInfoException;
+use App\Services\easymarket\ImageService\ImageServiceInterface;
+use Illuminate\Support\Facades\DB;
+
+class ProductService implements ProductServiceInterface
+{
+
+    /**
+    * @var ImageServiceInterface
+    */
+    private $imageService;
+
+    /**
+     * @param  ImageServiceInterface  $imageService
+     * @return void
+     */
+    public function __construct(
+        ImageServiceInterface $imageService
+    )
+    {
+        $this->imageService = $imageService;
+    }
+
+    /*
+     * 商品出品処理
+     * 
+     * @param StoreCommand $storeCommand
+     * @exception IncompleteSellerInfoException
+     * @return Product
+     */
+    public function store(StoreCommand $storeCommand): Product
+    {
+        $seller = $storeCommand->seller;
+        if (empty($seller->nickname)) {
+            throw new IncompleteSellerInfoException();
+        }
+
+        $product = DB::transaction(function () use ($storeCommand) {
+            $images = $this->imageService->saveUploadFiles($storeCommand->images);
+
+            $product = Product::create([
+                'name' => $storeCommand->name,
+                'description' => $storeCommand->description,
+                'price' => $storeCommand->price,
+            ]);
+            $product->save();
+
+            $deal = new Deal();
+            $deal->seller()->associate($storeCommand->seller);
+            $deal->product()->associate($product);
+            $deal->save();
+
+            $product->images()->saveMany($images);
+
+            $dealEvent = new DealEvent([
+                'actor_type' => DealEventActorType::Seller,
+                'event_type' => DealEventEventType::Listing,
+            ]);
+            $dealEvent->deal_eventable()->associate($storeCommand->seller);
+            $deal->dealEvents()->save($dealEvent);
+
+            return $product;
+        });
+
+        return $product;
+    }
+
+
+}

--- a/app/Services/easymarket/ProductService/ProductService.php
+++ b/app/Services/easymarket/ProductService/ProductService.php
@@ -8,6 +8,8 @@ use App\Services\easymarket\ProductService\Dtos\StoreCommand;
 use App\Services\easymarket\ProductService\Exceptions\IncompleteSellerInfoException;
 use App\Services\easymarket\ImageService\ImageServiceInterface;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Collection;
+
 
 class ProductService implements ProductServiceInterface
 {
@@ -26,6 +28,16 @@ class ProductService implements ProductServiceInterface
     )
     {
         $this->imageService = $imageService;
+    }
+
+    /*
+     * 商品取得
+     * 
+     * @return Collection<Product>
+     */
+    public function get(): Collection
+    {
+        return Product::orderBy('id', 'desc')->get();
     }
 
     /*

--- a/app/Services/easymarket/ProductService/ProductServiceInterface.php
+++ b/app/Services/easymarket/ProductService/ProductServiceInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services\easymarket\ProductService;
+
+use App\Models\Product;
+use App\Services\easymarket\ProductService\Dtos\StoreCommand;
+
+interface ProductServiceInterface
+{
+    /*
+     * @return Collection<Product>
+     */
+    public function store(StoreCommand $storeCommand): Product;
+}

--- a/app/Services/easymarket/ProductService/ProductServiceInterface.php
+++ b/app/Services/easymarket/ProductService/ProductServiceInterface.php
@@ -4,11 +4,13 @@ namespace App\Services\easymarket\ProductService;
 
 use App\Models\Product;
 use App\Services\easymarket\ProductService\Dtos\StoreCommand;
+use Illuminate\Support\Collection;
 
 interface ProductServiceInterface
 {
     /*
      * @return Collection<Product>
      */
+    public function get(): Collection;
     public function store(StoreCommand $storeCommand): Product;
 }

--- a/routes/easymarket_api.php
+++ b/routes/easymarket_api.php
@@ -3,6 +3,8 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\easymarket\API\AuthController;
 use App\Http\Controllers\easymarket\API\MeController;
+use App\Http\Controllers\easymarket\API\ProductController;
+
 
 
 
@@ -26,6 +28,9 @@ Route::middleware(['auth:easymarket_api', 'verified'])->group(function () {
 
     Route::get('/me', [MeController::class, 'show']);
     Route::put('/me', [MeController::class, 'update']);
+
+    Route::post('/products', [ProductController::class, 'store']);
+
 
 });
 

--- a/routes/easymarket_api.php
+++ b/routes/easymarket_api.php
@@ -23,6 +23,10 @@ Route::post('/auth/signup', [AuthController::class, 'signup']);
 Route::post('/auth/signup/verify', [AuthController::class, 'signupVerify']);
 Route::post('/auth/signin', [AuthController::class, 'signin']);
 
+Route::get('/products', [ProductController::class, 'index']);
+
+
+
 Route::middleware(['auth:easymarket_api', 'verified'])->group(function () {
     Route::post('/auth/signout', [AuthController::class, 'signout']);
 

--- a/routes/easymarket_api.php
+++ b/routes/easymarket_api.php
@@ -24,6 +24,7 @@ Route::post('/auth/signup/verify', [AuthController::class, 'signupVerify']);
 Route::post('/auth/signin', [AuthController::class, 'signin']);
 
 Route::get('/products', [ProductController::class, 'index']);
+Route::get('/products/{product}', [ProductController::class, 'show']);
 
 
 

--- a/tests/Feature/Controllers/easymarket/API/ProductController/GetProductTest.php
+++ b/tests/Feature/Controllers/easymarket/API/ProductController/GetProductTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Feature\Controllers\easymarket\API\ProductController;
+
+use App\Models\{Deal, DealEvent, Image, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class GetProductTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系
+     */
+    public function test_get_product(): void
+    {
+        $buyer = User::factory()->create();
+        $seller = User::factory()->create();
+        $products = Product::factory()->count(3)->create();
+        $images = Image::factory()->count(3)->create();
+        $products->each(function ($product, $index) use ($images) {
+            $product->images()->attach($images[$index]);
+        });
+
+        $deals = Deal::factory()->count(3)->state(new Sequence(
+            ['seller_id' => $seller->id, 'buyer_id' => $buyer->id, 'product_id' => $products[0]->id, 'status' => 'purchased'],
+            ['seller_id' => $seller->id, 'buyer_id' => null, 'product_id' => $products[1]->id, 'status' => 'listing'],
+            ['seller_id' => $seller->id, 'buyer_id' => null, 'product_id' => $products[2]->id, 'status' => 'listing']
+        ))->create();
+
+        $deals->each(function($deal) use ($seller) {
+            DealEvent::factory()->for($deal)->for($seller, 'deal_eventable')->create(['actor_type' => 'seller', 'event_type' => 'listing']);
+        });
+        DealEvent::factory()->for($deals[0])->for($buyer, 'deal_eventable')->create(['actor_type' => 'buyer', 'event_type' => 'purchase']);
+
+        $response = $this->getJson('/easymarket/api/products/' . $deals->get(0)->product_id);
+
+        $product = $products->get(0);
+        $deal = $products->get(0)->deal;
+
+        $response->assertStatus(200)
+            ->assertJson(
+                fn (AssertableJson $json) =>
+                $json->where('id', $product->id)
+                    ->where('name', $product->name)
+                    ->where('description', $product->description)
+                    ->whereType('image_url', 'string') 
+                    ->whereType('image_urls', 'array')
+                    ->where('price', $product->price)
+                    ->where('deal.id', $deal->id)
+                    ->where('deal.is_purchasable', $deal->is_purchasable)
+                    ->where('deal.seller_info.id', $deal->seller->id)
+                    ->where('deal.seller_info.nickname', $deal->seller->nickname)
+                    ->where('deal.seller_info.profile_image_url', $deal->seller->present()->profileImageUrl)
+                    ->where('deal.seller_info.description', $deal->seller->description)
+        );
+    }
+
+    /**
+     * 存在しないIDの時
+     */
+    public function test_get_product_not_found(): void
+    {
+        $response = $this->getJson('/easymarket/api/products/0');
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/Controllers/easymarket/API/ProductController/GetProductsTest.php
+++ b/tests/Feature/Controllers/easymarket/API/ProductController/GetProductsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Feature\Controllers\easymarket\API\ProductController;
+
+use App\Models\{Deal, DealEvent, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class GetProductsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系
+     */
+    public function test_get_products(): void
+    {
+        $buyer = User::factory()->create();
+        $seller = User::factory()->create();
+
+        $products = Product::factory()->count(3)->create();
+
+        $deals = Deal::factory()->count(3)->state(new Sequence(
+            ['seller_id' => $seller->id, 'buyer_id' => $buyer->id, 'product_id' => $products[0]->id, 'status' => 'purchased'],
+            ['seller_id' => $seller->id, 'buyer_id' => null, 'product_id' => $products[1]->id, 'status' => 'listing'],
+            ['seller_id' => $seller->id, 'buyer_id' => null, 'product_id' => $products[2]->id, 'status' => 'listing']
+        ))->create();
+
+        $deals->each(function($deal) use ($seller) {
+            DealEvent::factory()->for($deal)->for($seller, 'deal_eventable')->create(['actor_type' => 'seller', 'event_type' => 'listing']);
+        });
+
+        DealEvent::factory()->for($deals[0])->for($buyer, 'deal_eventable')->create(['actor_type' => 'buyer', 'event_type' => 'purchase']);
+
+        $response = $this->getJson('/easymarket/api/products');
+
+        $response->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json->has('products', 3))
+            ->assertJsonStructure([
+                'products' => [
+                    '*' => [
+                        'id',
+                        'name',
+                        'description',
+                        'image_url',
+                        'image_urls',
+                        'price',
+                        'deal' => [
+                            'id',
+                            'is_purchasable',
+                            'seller_info' => [
+                                'id',
+                                'nickname',
+                                'profile_image_url',
+                                'description',
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
+    /**
+     * データが0件の時
+     */
+    public function test_get_products_length_zero(): void
+    {
+        $this->assertDatabaseCount('products', 0);
+
+        $response = $this->getJson('/easymarket/api/products');
+
+        $response->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json->has('products', 0));
+    }
+}

--- a/tests/Feature/Controllers/easymarket/API/ProductController/PostProductTest.php
+++ b/tests/Feature/Controllers/easymarket/API/ProductController/PostProductTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Feature\Feature\Controllers\easymarket\API\ProductController;
+
+use App\Models\{User};
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class PostProductTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系
+     */
+    public function test_post_product(): void
+    {
+        $user = User::factory()->create();
+
+        Storage::fake('public');
+
+        $data = [
+            'name' => 'ABCバッグ',
+            'description' => 'ABCバッグです。新品です。',
+            'price' => 1234,
+            'images' => [
+                UploadedFile::fake()->image('image1.jpg'),
+                UploadedFile::fake()->image('image2.jpg'),
+                UploadedFile::fake()->image('image3.jpg')
+            ],
+        ];
+        $this->assertDatabaseCount('products', 0);
+
+        $response = $this->actingAs($user)
+                         ->postJson('/easymarket/api/products', $data);
+
+        $response->assertStatus(201)
+        ->assertJson(
+            fn (AssertableJson $json) =>
+            $json->whereType('id', 'integer')
+                ->where('name', $data['name'])
+                ->where('description', $data['description'])
+                ->whereType('image_url', 'string') 
+                ->whereType('image_urls', 'array')
+                ->has('image_urls', 3)
+                ->where('price', $data['price'])
+                ->whereType('deal.id', 'integer')
+                ->where('deal.is_purchasable', true)
+                ->where('deal.seller_info.id', $user->id)
+                ->where('deal.seller_info.nickname', $user->nickname)
+                ->where('deal.seller_info.profile_image_url', $user->present()->profileImageUrl)
+                ->where('deal.seller_info.description', $user->description)
+        );
+        $this->assertDatabaseCount('products', 1);
+    }
+
+    /**
+     * ニックネームが空白の場合は出品できない
+     */
+    public function test_post_product_nickname_is_empty(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create([
+            'nickname' => ''
+        ]);
+
+        $data = [
+            'name' => 'ABCバッグ',
+            'description' => 'ABCバッグです。新品です。',
+            'price' => 1234,
+            'images' => [
+                UploadedFile::fake()->image('image1.jpg'),
+                UploadedFile::fake()->image('image2.jpg'),
+                UploadedFile::fake()->image('image3.jpg')
+            ],
+        ];
+
+        $this->assertDatabaseCount('products', 0);
+
+        $response = $this->actingAs($user)
+                         ->postJson('/easymarket/api/products', $data);
+
+        $response->assertStatus(400);
+        $this->assertDatabaseCount('products', 0);
+        
+    }
+
+    /**
+     * バリデーションエラーの時
+     */
+    public function test_post_product_validation_error(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+                         ->postJson('/easymarket/api/products', []);
+
+        $response->assertStatus(422)
+        ->assertJson(
+            fn (AssertableJson $json) =>
+            $json->has('message')
+                ->has('errors', 4)
+                ->has(
+                    'errors.0',
+                    fn ($json) => $json->where('field', 'name')
+                        ->has('detail')
+                )
+                ->has(
+                    'errors.1',
+                    fn ($json) => $json->where('field', 'description')
+                        ->has('detail')
+                )
+                ->has(
+                    'errors.2',
+                    fn ($json) => $json->where('field', 'price')
+                        ->has('detail')
+                )
+                ->has(
+                    'errors.3',
+                    fn ($json) => $json->where('field', 'images')
+                        ->has('detail')
+                )
+        );
+    }
+}


### PR DESCRIPTION
# 概要
商品出品、一覧表示、詳細表示機能を実装しました。


# 実装機能
※各APIに正常系、異常系のテストを作っています。
出品API
商品一覧取得API
商品詳細取得API


## 技術的詳細
商品出品API

- 出品にはユーザーにnicknameが入っていないとエラーになる
- 出品に成功するとdeal_eventsテーブルにレコードが追加。event_typeはlistingとなる。
- dealsテーブルにもstatusがlisting、buyer_idがnullのレコードが追加される

商品一覧取得API*

- テストコードはassertJsonStructureで、返ってきたデータの構成が一致するか確認している。

商品詳細取得API

- 404エラーのテストを行う
- 商品詳細ページで出品者の個人情報が出ないようにSellerInfoResourceを作成