### PR TITLE
決済機能の実装

### DIFF
--- a/.github/workflows/mirror-to-codecommit.yml
+++ b/.github/workflows/mirror-to-codecommit.yml
@@ -1,19 +1,19 @@
-name: Mirror to AWS CodeCommit
+# name: Mirror AWS CodeCommit
 
-on: [push]
+# on: [push]
 
-jobs:
-  mirror:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout GitHub repository
-      uses: actions/checkout@v2
-    - name: Push to AWS CodeCommit
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: 'ap-northeast-1'
-      run: |
-        git config --global credential.helper '!aws codecommit credential-helper $@'
-        git config --global credential.UseHttpPath true
-        git push --mirror https://git-codecommit.ap-northeast-1.amazonaws.com/v1/repos/easymarket-backend
+# jobs:
+#   mirror:
+#     runs-on: ubuntu-latest
+#     steps:
+#     - name: Checkout GitHub repository
+#       uses: actions/checkout@v2
+#     - name: Push to AWS CodeCommit
+#       env:
+#         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#         AWS_REGION: 'ap-northeast-1'
+#       run: |
+#         git config --global credential.helper '!aws codecommit credential-helper $@'
+#         git config --global credential.UseHttpPath true
+#         git push --mirror https://git-codecommit.ap-northeast-1.amazonaws.com/v1/repos/easymarket-backend

--- a/.github/workflows/mirror-to-codecommit.yml
+++ b/.github/workflows/mirror-to-codecommit.yml
@@ -1,0 +1,17 @@
+name: Mirror to AWS CodeCommit
+
+on: [push]
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout GitHub repository
+      uses: actions/checkout@v2
+    - name: Push to AWS CodeCommit
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1' # CodeCommitリポジトリのリージョンに合わせてください
+      run: |
+        git push --mirror https://git-codecommit.ap-northeast-1.amazonaws.com/v1/repos/easymarket-backend

--- a/.github/workflows/mirror-to-codecommit.yml
+++ b/.github/workflows/mirror-to-codecommit.yml
@@ -14,4 +14,6 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'ap-northeast-1'
       run: |
+        git config --global credential.helper '!aws codecommit credential-helper $@'
+        git config --global credential.UseHttpPath true
         git push --mirror https://git-codecommit.ap-northeast-1.amazonaws.com/v1/repos/easymarket-backend

--- a/.github/workflows/mirror-to-codecommit.yml
+++ b/.github/workflows/mirror-to-codecommit.yml
@@ -12,6 +12,6 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: 'us-east-1' # CodeCommitリポジトリのリージョンに合わせてください
+        AWS_REGION: 'ap-northeast-1'
       run: |
         git push --mirror https://git-codecommit.ap-northeast-1.amazonaws.com/v1/repos/easymarket-backend

--- a/app/Http/Controllers/easymarket/API/MeController.php
+++ b/app/Http/Controllers/easymarket/API/MeController.php
@@ -16,6 +16,7 @@ use App\Services\easymarket\UserService\UserServiceInterface;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Resources\easymarket\API\DealForMyPageResource;
 use App\Http\Resources\easymarket\API\ProductForMyPageCollection;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class MeController extends Controller
 {
@@ -112,8 +113,10 @@ class MeController extends Controller
         /** @var \App\Models\User $user */
         $user = Auth::user();
         $products = $this->productService->getListedProductsByUser($user);
+
         return new ProductForMyPageCollection($products);
     }
+    
 
     /**
      * 出品商品の取引詳細情報取得API

--- a/app/Http/Controllers/easymarket/API/MeController.php
+++ b/app/Http/Controllers/easymarket/API/MeController.php
@@ -3,12 +3,19 @@
 namespace App\Http\Controllers\easymarket\API;
 
 use App\Http\Controllers\Controller;
+use App\Models\Product;
 use App\Http\Requests\easymarket\API\Me\ShowRequest;
 use App\Http\Requests\easymarket\API\Me\UpdateRequest;
+use App\Http\Requests\easymarket\API\Me\GetPurchasedProductsRequest;
+use App\Http\Requests\easymarket\API\Me\GetPurchasedProductDealRequest;
+use App\Http\Requests\easymarket\API\Me\GetListedProductsRequest;
+use App\Http\Requests\easymarket\API\Me\GetListedProductDealRequest;
 use App\Http\Resources\easymarket\API\MeResource;
 use App\Services\easymarket\ProductService\ProductServiceInterface;
 use App\Services\easymarket\UserService\UserServiceInterface;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Resources\easymarket\API\DealForMyPageResource;
+use App\Http\Resources\easymarket\API\ProductForMyPageCollection;
 
 class MeController extends Controller
 {
@@ -30,10 +37,13 @@ class MeController extends Controller
      */
     public function __construct(
         UserServiceInterface $userService,
+        ProductServiceInterface $productService
     )
     {
         $this->userService = $userService;
+        $this->productService = $productService;
     }
+
 
     /**
      * ログインユーザー情報取得API
@@ -64,6 +74,59 @@ class MeController extends Controller
 
         return new MeResource($user);
     }
+
+        /**
+     * 購入商品一覧取得API
+     * 
+     * @param  GetPurchasedProductsRequest  $request
+     * @return ProductForMyPageCollection
+     */
+    public function getPurchasedProducts(GetPurchasedProductsRequest $request)
+    {
+        /** @var \App\Models\User $user */
+        $user = Auth::user();
+        $products = $this->productService->getPurchasedProductsByUser($user);
+        return new ProductForMyPageCollection($products);
+    }
+
+    /**
+     * 購入商品の取引詳細情報取得API
+     * 
+     * @param  GetPurchasedProductDealRequest  $request
+     * @return DealForMyPageResource
+     */
+    public function getPurchasedProductDeal(GetPurchasedProductDealRequest $request, Product $product)
+    {
+        $product->deal->load('dealEvents');
+        return new DealForMyPageResource($product->deal);
+    }
+
+    /**
+     * 出品商品一覧取得API
+     * 
+     * @param  GetListedProductsRequest  $request
+     * @return ProductForMyPageCollection
+     */
+    public function getListedProducts(GetListedProductsRequest $request)
+    {
+        /** @var \App\Models\User $user */
+        $user = Auth::user();
+        $products = $this->productService->getListedProductsByUser($user);
+        return new ProductForMyPageCollection($products);
+    }
+
+    /**
+     * 出品商品の取引詳細情報取得API
+     * 
+     * @param  GetListedProductDealRequest  $request
+     * @return DealForMyPageResource
+     */
+    public function getListedProductDeal(GetListedProductDealRequest $request, Product $product)
+    {
+        $product->deal->load('dealEvents');
+        return new DealForMyPageResource($product->deal);
+    }
+
 
 
 }

--- a/app/Http/Controllers/easymarket/API/ProductDealController.php
+++ b/app/Http/Controllers/easymarket/API/ProductDealController.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\easymarket\API\ProductDeal\CancelRequest;
 use App\Http\Requests\easymarket\API\ProductDeal\CreatePaymentIntentRequest;
 use App\Http\Requests\easymarket\API\ProductDeal\VerifyPaymentIntentRequest;
+use App\Http\Requests\easymarket\API\ProductDeal\ReportDeliveryRequest;
+use App\Http\Requests\easymarket\API\ProductDeal\ReportReceiptRequest;
 //
 use App\Http\Resources\easymarket\API\PaymentIntentResource;
 use App\Http\Resources\easymarket\API\DealForMyPageResource;
@@ -105,6 +107,50 @@ class ProductDealController extends Controller
 
         try {
             $deal = $this->dealService->cancel($product->deal, $seller);
+        } catch (InvalidStatusTransitionException $e) {
+            throw new APIBusinessLogicException($e->getMessage(), 400);
+        }
+        $deal->load('dealEvents');
+
+        return new DealForMyPageResource($deal);
+    }
+
+    /**
+     * 配送報告API
+     * 
+     * @param  ReportDeliveryRequest  $request
+     * @param  Product  $product
+     * @return DealForMyPageResource
+     */
+    public function reportDelivery(ReportDeliveryRequest $request, Product $product)
+    {
+        /** @var \App\Models\User $seller */
+        $seller = Auth::user();
+
+        try {
+            $deal = $this->dealService->reportDelivery($product->deal, $seller);
+        } catch (InvalidStatusTransitionException $e) {
+            throw new APIBusinessLogicException($e->getMessage(), 400);
+        }
+        $deal->load('dealEvents');
+
+        return new DealForMyPageResource($deal);
+    }
+
+    /**
+     * 受取報告API
+     * 
+     * @param  ReportReceiptRequest  $request
+     * @param  Product  $product
+     * @return DealForMyPageResource
+     */
+    public function reportReceipt(ReportReceiptRequest $request, Product $product)
+    {
+        /** @var \App\Models\User $buyer */
+        $buyer = Auth::user();
+
+        try {
+            $deal = $this->dealService->reportReceipt($product->deal, $buyer);
         } catch (InvalidStatusTransitionException $e) {
             throw new APIBusinessLogicException($e->getMessage(), 400);
         }

--- a/app/Http/Controllers/easymarket/API/ProductDealController.php
+++ b/app/Http/Controllers/easymarket/API/ProductDealController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\easymarket\API;
+
+use App\Exceptions\APIBusinessLogicException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\easymarket\API\ProductDeal\CancelRequest;
+use App\Http\Requests\easymarket\API\ProductDeal\CreatePaymentIntentRequest;
+use App\Http\Resources\easymarket\API\PaymentIntentResource;
+use App\Models\Product;
+
+use App\Services\easymarket\DealService\DealServiceInterface;
+use App\Services\easymarket\DealService\Exceptions\InvalidStatusTransitionException;
+use App\Services\easymarket\DealService\Exceptions\IncompleteBuyerShippingInfoException;
+use App\Services\easymarket\DealService\Exceptions\PaymentIntentIsNotSucceededException;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
+
+class ProductDealController extends Controller
+{
+
+    /**
+    * @var DealServiceInterface
+    */
+    private $dealService;
+
+    /**
+     * @param  DealServiceInterface  $dealService
+     * @return void
+     */
+    public function __construct(
+        DealServiceInterface $dealService,
+    )
+    {
+        $this->dealService = $dealService;
+    }
+
+    /**
+     * 商品支払いインテント作成API
+     * 
+     * @param  CreatePaymentIntentRequest  $request
+     * @param  Product  $product
+     * @return PaymentIntentResource
+     */
+    public function createPaymentIntent(CreatePaymentIntentRequest $request, Product $product)
+    {
+        /** @var \App\Models\User $buyer */
+        $buyer = Auth::user();
+        try {
+            $paymentIntent = $this->dealService->createPaymentIntent($product->deal, $buyer);
+        } catch (InvalidStatusTransitionException $e) {
+            throw new APIBusinessLogicException($e->getMessage(), 400);
+        } catch (IncompleteBuyerShippingInfoException $e) {
+            throw new APIBusinessLogicException($e->getMessage(), 400);
+        } catch (PaymentIntentIsNotSucceededException $e) {
+            throw new APIBusinessLogicException($e->getMessage(), 400);
+        }
+
+        return new PaymentIntentResource($paymentIntent);
+    }
+
+
+}

--- a/app/Http/Controllers/easymarket/API/ProductDealController.php
+++ b/app/Http/Controllers/easymarket/API/ProductDealController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\easymarket\API\ProductDeal\CancelRequest;
 use App\Http\Requests\easymarket\API\ProductDeal\CreatePaymentIntentRequest;
 use App\Http\Requests\easymarket\API\ProductDeal\VerifyPaymentIntentRequest;
+//
 use App\Http\Resources\easymarket\API\PaymentIntentResource;
 use App\Http\Resources\easymarket\API\DealForMyPageResource;
 use App\Models\Product;
@@ -15,6 +16,7 @@ use App\Services\easymarket\DealService\DealServiceInterface;
 use App\Services\easymarket\DealService\Exceptions\InvalidStatusTransitionException;
 use App\Services\easymarket\DealService\Exceptions\IncompleteBuyerShippingInfoException;
 use App\Services\easymarket\DealService\Exceptions\PaymentIntentIsNotSucceededException;
+
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
@@ -88,6 +90,29 @@ class ProductDealController extends Controller
 
         return new DealForMyPageResource($deal);
     }
+
+    /**
+     * 商品出品キャンセルAPI
+     * 
+     * @param  CancelRequest  $request
+     * @param  Product  $product
+     * @return DealForMyPageResource
+     */
+    public function cancel(CancelRequest $request, Product $product)
+    {
+        /** @var \App\Models\User $seller */
+        $seller = Auth::user();
+
+        try {
+            $deal = $this->dealService->cancel($product->deal, $seller);
+        } catch (InvalidStatusTransitionException $e) {
+            throw new APIBusinessLogicException($e->getMessage(), 400);
+        }
+        $deal->load('dealEvents');
+
+        return new DealForMyPageResource($deal);
+    }
+
 
     
 

--- a/app/Http/Requests/easymarket/API/Me/GetListedProductDealRequest.php
+++ b/app/Http/Requests/easymarket/API/Me/GetListedProductDealRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\Me;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetListedProductDealRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/easymarket/API/Me/GetListedProductsRequest.php
+++ b/app/Http/Requests/easymarket/API/Me/GetListedProductsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\Me;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetListedProductsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/easymarket/API/Me/GetListedProductsRequest.php
+++ b/app/Http/Requests/easymarket/API/Me/GetListedProductsRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\easymarket\API\Me;
 
 use Illuminate\Foundation\Http\FormRequest;
-
+use Illuminate\Support\Facades\Log;
 class GetListedProductsRequest extends FormRequest
 {
     /**
@@ -11,6 +11,7 @@ class GetListedProductsRequest extends FormRequest
      */
     public function authorize(): bool
     {
+        
         return true;
     }
 

--- a/app/Http/Requests/easymarket/API/Me/GetPurchasedProductDealRequest.php
+++ b/app/Http/Requests/easymarket/API/Me/GetPurchasedProductDealRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\Me;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetPurchasedProductDealRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/easymarket/API/Me/GetPurchasedProductsRequest.php
+++ b/app/Http/Requests/easymarket/API/Me/GetPurchasedProductsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\Me;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetPurchasedProductsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/easymarket/API/ProductDeal/CancelRequest.php
+++ b/app/Http/Requests/easymarket/API/ProductDeal/CancelRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\ProductDeal;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CancelRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        /** @var \App\Models\Product $product */
+        $product = $this->route('product');
+        $deal = $product->deal;
+
+        if ($this->user()->cannot('cancel-deal', $deal)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Handle a failed authorization attempt.
+     *
+     * @return void
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    protected function failedAuthorization()
+    {
+        throw new \Illuminate\Auth\Access\AuthorizationException('出品キャンセルできないユーザーです。');
+    }
+}

--- a/app/Http/Requests/easymarket/API/ProductDeal/CreatePaymentIntentRequest.php
+++ b/app/Http/Requests/easymarket/API/ProductDeal/CreatePaymentIntentRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\ProductDeal;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreatePaymentIntentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        /** @var \App\Models\Product $product */
+        $product = $this->route('product');
+        $deal = $product->deal;
+
+        if ($this->user()->cannot('purchase-deal', $deal)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Handle a failed authorization attempt.
+     *
+     * @return void
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    protected function failedAuthorization()
+    {
+        throw new \Illuminate\Auth\Access\AuthorizationException('商品を購入できないユーザーです。');
+    }
+}

--- a/app/Http/Requests/easymarket/API/ProductDeal/ReportDeliveryRequest.php
+++ b/app/Http/Requests/easymarket/API/ProductDeal/ReportDeliveryRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\ProductDeal;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReportDeliveryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        /** @var \App\Models\Product $product */
+        $product = $this->route('product');
+        $deal = $product->deal;
+
+        if ($this->user()->cannot('report-delivery-deal', $deal)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Handle a failed authorization attempt.
+     *
+     * @return void
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    protected function failedAuthorization()
+    {
+        throw new \Illuminate\Auth\Access\AuthorizationException('配送報告できないユーザーです。');
+    }
+}

--- a/app/Http/Requests/easymarket/API/ProductDeal/ReportReceiptRequest.php
+++ b/app/Http/Requests/easymarket/API/ProductDeal/ReportReceiptRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\ProductDeal;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReportReceiptRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        /** @var \App\Models\Product $product */
+        $product = $this->route('product');
+        $deal = $product->deal;
+
+        if ($this->user()->cannot('report-receipt-deal', $deal)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Handle a failed authorization attempt.
+     *
+     * @return void
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    protected function failedAuthorization()
+    {
+        throw new \Illuminate\Auth\Access\AuthorizationException('受取報告できないユーザーです。');
+    }
+}

--- a/app/Http/Requests/easymarket/API/ProductDeal/VerifyPaymentIntentRequest.php
+++ b/app/Http/Requests/easymarket/API/ProductDeal/VerifyPaymentIntentRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests\easymarket\API\ProductDeal;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class VerifyPaymentIntentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        /** @var \App\Models\Product $product */
+        $product = $this->route('product');
+        $deal = $product->deal;
+
+        if ($this->user()->cannot('purchase-deal', $deal)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'payment_intent_id' => 'required|string|max:255',
+        ];
+    }
+
+    /**
+     * Handle a failed authorization attempt.
+     *
+     * @return void
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    protected function failedAuthorization()
+    {
+        throw new \Illuminate\Auth\Access\AuthorizationException('商品を購入できないユーザーです。');
+    }
+}

--- a/app/Http/Resources/easymarket/API/BuyerShippingInfoResource.php
+++ b/app/Http/Resources/easymarket/API/BuyerShippingInfoResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources\easymarket\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\User */
+class BuyerShippingInfoResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'postal_code' => $this->postal_code,
+            'address' => $this->address,
+            'nickname' => $this->nickname,
+            'profile_image_url' => $this->present()->profileImageUrl,
+            'description' => $this->description,
+        ];
+    }
+}

--- a/app/Http/Resources/easymarket/API/DealEventResource.php
+++ b/app/Http/Resources/easymarket/API/DealEventResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\easymarket\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\DealEvent */
+class DealEventResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'actor_type' => $this->actor_type,
+            'event_type' => $this->event_type,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/app/Http/Resources/easymarket/API/DealForMypageResource.php
+++ b/app/Http/Resources/easymarket/API/DealForMypageResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources\easymarket\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Deal */
+class DealForMyPageResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'is_purchasable' => $this->is_purchasable,
+            'seller_info' => new SellerInfoResource($this->seller),
+            'buyer_shipping_info' => new BuyerShippingInfoResource($this->buyer),
+            'status' => $this->status,
+            'deal_events' => DealEventResource::collection($this->whenLoaded('dealEvents')),
+        ];
+    }
+}

--- a/app/Http/Resources/easymarket/API/PaymentIntentResource.php
+++ b/app/Http/Resources/easymarket/API/PaymentIntentResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources\easymarket\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \Stripe\PaymentIntent */
+class PaymentIntentResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'client_secret' => $this->client_secret,
+        ];
+    }
+}

--- a/app/Http/Resources/easymarket/API/ProductForMyPageCollection.php
+++ b/app/Http/Resources/easymarket/API/ProductForMyPageCollection.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources\easymarket\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ProductForMyPageCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @return array<int|string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'products' => $this->collection,
+        ];
+    }
+}

--- a/app/Policies/EasyMarket/API/DealPolicy.php
+++ b/app/Policies/EasyMarket/API/DealPolicy.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Policies\easymarket\API;
+
+use App\Models\Deal;
+use App\Models\User;
+
+class DealPolicy
+{
+    /**
+     * Create a new policy instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * 商品購入API
+     * 
+     * @param User $user
+     * @param Deal $deal
+     * @return bool
+     */
+    public function purchaseDeal(User $user, Deal $deal): bool
+    {
+        // 出品者が自分ではない場合のみアクセス可
+        return $user->id !== $deal->seller_id;
+    }
+
+    /**
+     * 商品出品キャンセルAPI
+     * 
+     * @param User $user
+     * @param Deal $deal
+     * @return bool
+     */
+    public function cancelDeal(User $user, Deal $deal): bool
+    {
+        // 出品者が自分である場合のみアクセス可
+        return $user->id === $deal->seller_id;
+    }
+
+    /**
+     * 配送報告API
+     * 
+     * @param User $user
+     * @param Deal $deal
+     * @return bool
+     */
+    public function reportDeliveryDeal(User $user, Deal $deal): bool
+    {
+        // 出品者が自分である場合のみアクセス可
+        return $user->id === $deal->seller_id;
+    }
+
+    /**
+     * 受取報告API
+     * 
+     * @param User $user
+     * @param Deal $deal
+     * @return bool
+     */
+    public function reportReceiptDeal(User $user, Deal $deal): bool
+    {
+        // 購入者が自分である場合のみアクセス可
+        return $user->id === $deal->buyer_id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+use App\Models\Deal;
+use App\Policies\easymarket\API\DealPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -13,7 +15,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        //
+        Deal::class => DealPolicy::class,
     ];
 
     /**

--- a/app/Providers/ServiceeasymarketServiceProvider.php
+++ b/app/Providers/ServiceeasymarketServiceProvider.php
@@ -18,6 +18,10 @@ class ServiceeasymarketServiceProvider extends ServiceProvider
             \App\Services\easymarket\AuthService\AuthService::class
         );
         $this->app->bind(
+            \App\Services\easymarket\DealService\DealServiceInterface::class,
+            \App\Services\easymarket\DealService\DealService::class
+        );
+        $this->app->bind(
             \App\Services\easymarket\ImageService\ImageServiceInterface::class,
             \App\Services\easymarket\ImageService\ImageService::class
         );
@@ -29,6 +33,18 @@ class ServiceeasymarketServiceProvider extends ServiceProvider
             \App\Services\easymarket\ProductService\ProductServiceInterface::class,
             \App\Services\easymarket\ProductService\ProductService::class
         );
+        // envがtestingか、services.stripe.secretが設定されていない場合はStripeServiceのモックを返す
+        if (app()->environment('testing') || empty(config('services.stripe.secret'))) {
+            $this->app->bind(
+                \App\Services\easymarket\StripeService\StripeServiceInterface::class,
+                \App\Services\easymarket\StripeService\StripeServiceMock::class
+            );
+        } else {
+            $this->app->bind(
+                \App\Services\easymarket\StripeService\StripeServiceInterface::class,
+                \App\Services\easymarket\StripeService\StripeService::class
+            );
+        }        
     }
 
     /**

--- a/app/Services/easymarket/DealService/DealService.php
+++ b/app/Services/easymarket/DealService/DealService.php
@@ -5,9 +5,14 @@ namespace App\Services\easymarket\DealService;
 use App\Enums\DealStatus;
 use App\Models\Deal;
 use App\Models\User;
+use App\Models\DealEvent;
 use App\Services\easymarket\DealService\Exceptions\IncompleteBuyerShippingInfoException;
 use App\Services\easymarket\DealService\Exceptions\InvalidStatusTransitionException;
 use App\Services\easymarket\StripeService\StripeServiceInterface;
+use App\Services\easymarket\DealService\Exceptions\PaymentIntentIsNotSucceededException;
+use Illuminate\Support\Facades\DB;
+use App\Enums\DealEventActorType;
+use App\Enums\DealEventEventType;
 
 use Stripe\PaymentIntent;
 use Stripe\Stripe;
@@ -69,5 +74,41 @@ class DealService implements DealServiceInterface
         if (!in_array($deal->status, [DealStatus::Listing])) {
             throw new InvalidStatusTransitionException();
         }
+    }
+
+    /*
+     * 商品購入
+     * 
+     * @param Deal $deal
+     * @param User $buyer
+     * @exception IncompleteBuyerShippingInfoException
+     * @exception InvalidStatusTransitionException
+     * @exception PaymentIntentIsNotSucceededException
+     * @return Deal
+     */
+    public function verifyPaymentIntent(Deal $deal, User $buyer, string $paymentIntentId): Deal
+    {
+        $this->validateToPurchase($deal, $buyer);
+
+        if (!$this->stripeService->verifyPaymentIntent($paymentIntentId)) {
+            throw new PaymentIntentIsNotSucceededException();
+        }
+
+        $deal = DB::transaction(function () use ($deal, $buyer) {
+            $deal->buyer()->associate($buyer);
+            $deal->status = DealStatus::Purchased;
+            $deal->save();
+
+            $dealEvent = new DealEvent([
+                'actor_type' => DealEventActorType::Buyer,
+                'event_type' => DealEventEventType::Purchase,
+            ]);
+            $dealEvent->deal_eventable()->associate($buyer);
+            $deal->dealEvents()->save($dealEvent);
+
+            return $deal->fresh();
+        });
+
+        return $deal;
     }
 }

--- a/app/Services/easymarket/DealService/DealService.php
+++ b/app/Services/easymarket/DealService/DealService.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Services\easymarket\DealService;
+
+use App\Enums\DealStatus;
+use App\Models\Deal;
+use App\Models\User;
+use App\Services\easymarket\DealService\Exceptions\IncompleteBuyerShippingInfoException;
+use App\Services\easymarket\DealService\Exceptions\InvalidStatusTransitionException;
+use App\Services\easymarket\StripeService\StripeServiceInterface;
+
+use Stripe\PaymentIntent;
+use Stripe\Stripe;
+
+class DealService implements DealServiceInterface
+{
+
+    /**
+    * @var StripeServiceInterface
+    */
+    private $stripeService;
+
+    /**
+     * @param  StripeServiceInterface  $stripeService
+     * @return void
+     */
+    public function __construct(
+        StripeServiceInterface $stripeService
+    )
+    {
+        $this->stripeService = $stripeService;
+    }
+
+    /*
+     * PaymentIntentを作成する
+     * 
+     * @param Deal $deal
+     * @param User $buyer
+     * @exception IncompleteBuyerShippingInfoException
+     * @exception InvalidStatusTransitionException
+     * @return PaymentIntent
+     */
+    public function createPaymentIntent(Deal $deal, User $buyer): PaymentIntent
+    {
+        $this->validateToPurchase($deal, $buyer);
+
+        $paymentIntent = $this->stripeService->createPaymentIntent($deal->product, $buyer);
+
+        return $paymentIntent;
+    }
+
+
+
+    /*
+     * 商品購入についてバリデーションチェック
+     * 
+     * @param Deal $deal
+     * @param User $buyer
+     * @exception IncompleteBuyerShippingInfoException
+     * @exception InvalidStatusTransitionException
+     * @return void
+     */
+    private function validateToPurchase(Deal $deal, User $buyer): void
+    {
+        if (empty($buyer->name) || empty($buyer->postal_code) || empty($buyer->address)) {
+            throw new IncompleteBuyerShippingInfoException();
+        }
+
+        if (!in_array($deal->status, [DealStatus::Listing])) {
+            throw new InvalidStatusTransitionException();
+        }
+    }
+}

--- a/app/Services/easymarket/DealService/DealService.php
+++ b/app/Services/easymarket/DealService/DealService.php
@@ -141,4 +141,64 @@ class DealService implements DealServiceInterface
 
         return $deal;
     }
+
+    /*
+     * 配送報告
+     * 
+     * @param Deal $deal
+     * @param User $seller
+     * @exception InvalidStatusTransitionException
+     * @return Deal
+     */
+    public function reportDelivery(Deal $deal, User $seller): Deal
+    {
+        if (!in_array($deal->status, [DealStatus::Purchased])) {
+            throw new InvalidStatusTransitionException();
+        }
+        
+        $deal = DB::transaction(function () use ($deal, $seller) {
+            $deal->update(['status' => DealStatus::Shipping]);
+
+            $dealEvent = new DealEvent([
+                'actor_type' => DealEventActorType::Seller,
+                'event_type' => DealEventEventType::ReportDelivery,
+            ]);
+            $dealEvent->deal_eventable()->associate($seller);
+            $deal->dealEvents()->save($dealEvent);
+
+            return $deal->fresh();
+        });
+
+        return $deal;
+    }
+
+    /*
+     * 受取報告
+     * 
+     * @param Deal $deal
+     * @param User $buyer
+     * @exception InvalidStatusTransitionException
+     * @return Deal
+     */
+    public function reportReceipt(Deal $deal, User $buyer): Deal
+    {
+        if (!in_array($deal->status, [DealStatus::Shipping])) {
+            throw new InvalidStatusTransitionException();
+        }
+        
+        $deal = DB::transaction(function () use ($deal, $buyer) {
+            $deal->update(['status' => DealStatus::Completed]);
+
+            $dealEvent = new DealEvent([
+                'actor_type' => DealEventActorType::Buyer,
+                'event_type' => DealEventEventType::ReportReceipt,
+            ]);
+            $dealEvent->deal_eventable()->associate($buyer);
+            $deal->dealEvents()->save($dealEvent);
+
+            return $deal->fresh();
+        });
+
+        return $deal;
+    }
 }

--- a/app/Services/easymarket/DealService/DealServiceInterface.php
+++ b/app/Services/easymarket/DealService/DealServiceInterface.php
@@ -11,4 +11,6 @@ interface DealServiceInterface
     public function createPaymentIntent(Deal $deal, User $buyer): PaymentIntent;
     public function verifyPaymentIntent(Deal $deal, User $buyer, string $paymentIntentId): Deal;
     public function cancel(Deal $deal, User $seller): Deal;
+    public function reportDelivery(Deal $deal, User $seller): Deal;
+    public function reportReceipt(Deal $deal, User $buyer): Deal;
 }

--- a/app/Services/easymarket/DealService/DealServiceInterface.php
+++ b/app/Services/easymarket/DealService/DealServiceInterface.php
@@ -10,4 +10,5 @@ interface DealServiceInterface
 {
     public function createPaymentIntent(Deal $deal, User $buyer): PaymentIntent;
     public function verifyPaymentIntent(Deal $deal, User $buyer, string $paymentIntentId): Deal;
+    public function cancel(Deal $deal, User $seller): Deal;
 }

--- a/app/Services/easymarket/DealService/DealServiceInterface.php
+++ b/app/Services/easymarket/DealService/DealServiceInterface.php
@@ -9,4 +9,5 @@ use Stripe\PaymentIntent;
 interface DealServiceInterface
 {
     public function createPaymentIntent(Deal $deal, User $buyer): PaymentIntent;
+    public function verifyPaymentIntent(Deal $deal, User $buyer, string $paymentIntentId): Deal;
 }

--- a/app/Services/easymarket/DealService/DealServiceInterface.php
+++ b/app/Services/easymarket/DealService/DealServiceInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Services\easymarket\DealService;
+
+use App\Models\Deal;
+use App\Models\User;
+use Stripe\PaymentIntent;
+
+interface DealServiceInterface
+{
+    public function createPaymentIntent(Deal $deal, User $buyer): PaymentIntent;
+}

--- a/app/Services/easymarket/DealService/Exceptions/IncompleteBuyerShippingInfoException.php
+++ b/app/Services/easymarket/DealService/Exceptions/IncompleteBuyerShippingInfoException.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Services\easymarket\DealService\Exceptions;
+
+use Exception;
+
+class IncompleteBuyerShippingInfoException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('購入者情報が不足しています。購入するためには、購入者情報を入力してください。');
+    }
+}

--- a/app/Services/easymarket/DealService/Exceptions/InvalidStatusTransitionException.php
+++ b/app/Services/easymarket/DealService/Exceptions/InvalidStatusTransitionException.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Services\easymarket\DealService\Exceptions;
+
+use Exception;
+
+class InvalidStatusTransitionException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('取引のステータス遷移が不正です。');
+    }
+}

--- a/app/Services/easymarket/DealService/Exceptions/PaymentIntentIsNotSucceeded.php
+++ b/app/Services/easymarket/DealService/Exceptions/PaymentIntentIsNotSucceeded.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Services\easymarket\DealService\Exceptions;
+
+use Exception;
+
+class PaymentIntentIsNotSucceededException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('決済処理が完了していません。');
+    }
+}

--- a/app/Services/easymarket/ProductService/ProductService.php
+++ b/app/Services/easymarket/ProductService/ProductService.php
@@ -92,7 +92,25 @@ class ProductService implements ProductServiceInterface
      */
     public function getPurchasedProductsByUser(User $user): Collection
     {
-        $products = $user->dealsAsBuyer()->with('product')->get()->pluck('product');
+        // $products = $user->dealsAsBuyer()->with('product')->get()->pluck('product');
+        $products = $user->dealsAsBuyer()
+                ->with(['product.images', 'product.deal']) // product.deal を追加してリレーションをロード
+                ->get()
+                ->map(function ($deal) {
+                    $product = $deal->product;
+                    if ($product) {
+                        // Product に対応する最初の画像の URL を取得
+                        $imageUrl = optional($product->images->first())->file_path;
+                        // Deal のステータスを取得
+                        $dealStatus = $deal->status;
+                        // Product に画像 URL と Deal ステータスを追加
+                        $product->image_url = $imageUrl;
+                        $product->deal_status = $dealStatus;
+                        return $product;
+                    }
+                })
+                ->filter()
+                ->values();
         return $products;
     }
 
@@ -104,9 +122,29 @@ class ProductService implements ProductServiceInterface
      */
     public function getListedProductsByUser(User $user): Collection
     {
-        $products = $user->dealsAsSeller()->with('product')->get()->pluck('product');
+        // $products = $user->dealsAsSeller()->with('product')->get()->pluck('product');
+        $products = $user->dealsAsSeller()
+                ->with(['product.images', 'product.deal']) // product.deal を追加してリレーションをロード
+                ->get()
+                ->map(function ($deal) {
+                    $product = $deal->product;
+                    if ($product) {
+                        // Product に対応する最初の画像の URL を取得
+                        $imageUrl = optional($product->images->first())->file_path;
+                        // Deal のステータスを取得
+                        $dealStatus = $deal->status;
+                        // Product に画像 URL と Deal ステータスを追加
+                        $product->image_url = $imageUrl;
+                        $product->deal_status = $dealStatus;
+                        return $product;
+                    }
+                })
+                ->filter()
+                ->values();
+
         return $products;
     }
+    
 
 
 }

--- a/app/Services/easymarket/ProductService/ProductService.php
+++ b/app/Services/easymarket/ProductService/ProductService.php
@@ -84,5 +84,29 @@ class ProductService implements ProductServiceInterface
         return $product;
     }
 
+    /*
+     * 購入商品一覧取得
+     * 
+     * @param User $user
+     * @return Collection<Product>
+     */
+    public function getPurchasedProductsByUser(User $user): Collection
+    {
+        $products = $user->dealsAsBuyer()->with('product')->get()->pluck('product');
+        return $products;
+    }
+
+    /*
+     * 出品商品一覧取得
+     * 
+     * @param User $user
+     * @return Collection<Product>
+     */
+    public function getListedProductsByUser(User $user): Collection
+    {
+        $products = $user->dealsAsSeller()->with('product')->get()->pluck('product');
+        return $products;
+    }
+
 
 }

--- a/app/Services/easymarket/ProductService/ProductServiceInterface.php
+++ b/app/Services/easymarket/ProductService/ProductServiceInterface.php
@@ -3,6 +3,7 @@
 namespace App\Services\easymarket\ProductService;
 
 use App\Models\Product;
+use App\Models\User;
 use App\Services\easymarket\ProductService\Dtos\StoreCommand;
 use Illuminate\Support\Collection;
 
@@ -13,4 +14,13 @@ interface ProductServiceInterface
      */
     public function get(): Collection;
     public function store(StoreCommand $storeCommand): Product;
+    /*
+     * @return Collection<Product>
+     */
+    public function getPurchasedProductsByUser(User $user): Collection;
+    /*
+     * @return Collection<Product>
+     */
+    public function getListedProductsByUser(User $user): Collection;
+
 }

--- a/app/Services/easymarket/StripeService/StripeService.php
+++ b/app/Services/easymarket/StripeService/StripeService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services\easymarket\StripeService;
+
+use App\Models\Product;
+use App\Models\User;
+use Stripe\PaymentIntent;
+use Stripe\Stripe;
+
+class StripeService implements StripeServiceInterface
+{
+    public function createPaymentIntent(Product $product, User $buyer): PaymentIntent
+    {
+        Stripe::setApiKey(config('services.stripe.secret'));
+
+        $paymentIntent = PaymentIntent::create([
+            'amount' => $product->price,
+            'currency' => 'jpy',
+            'automatic_payment_methods' => [
+                'enabled' => true,
+            ],
+        ]);
+
+        return $paymentIntent;
+    }
+
+    public function verifyPaymentIntent(string $paymentIntentId): bool
+    {
+        Stripe::setApiKey(config('services.stripe.secret'));
+
+        $paymentIntent = PaymentIntent::retrieve($paymentIntentId);
+
+        return $paymentIntent->status === 'succeeded';
+    }
+}

--- a/app/Services/easymarket/StripeService/StripeServiceInterface.php
+++ b/app/Services/easymarket/StripeService/StripeServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Services\easymarket\StripeService;
+
+use App\Models\Product;
+use App\Models\User;
+use Stripe\PaymentIntent;
+
+interface StripeServiceInterface
+{
+    public function createPaymentIntent(Product $product, User $buyer): PaymentIntent;
+    public function verifyPaymentIntent(string $paymentIntentId): bool;
+}

--- a/app/Services/easymarket/StripeService/StripeServiceMock.php
+++ b/app/Services/easymarket/StripeService/StripeServiceMock.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services\easymarket\StripeService;
+
+use App\Models\Product;
+use App\Models\User;
+use Stripe\PaymentIntent;
+
+class StripeServiceMock implements StripeServiceInterface
+{
+    public function createPaymentIntent(Product $product, User $buyer): PaymentIntent
+    {
+        // PaymentIntentをモックするために固定の値を返す
+        return (new PaymentIntent())::constructFrom([
+            'id' => 'pi_123',
+            'amount' => $product->price,
+            'currency' => 'jpy',
+            'status' => 'requires_payment_method',
+            'automatic_payment_methods' => [
+                'enabled' => true,
+            ],
+            'client_secret' => 'pi_123_secret_123',
+        ]);
+    }
+
+    public function verifyPaymentIntent(string $paymentIntentId): bool
+    {
+        // 決済が成功したことを示すためにtrueを返す
+        return true;
+    }
+}

--- a/routes/easymarket_api.php
+++ b/routes/easymarket_api.php
@@ -44,6 +44,8 @@ Route::middleware(['auth:easymarket_api', 'verified'])->group(function () {
     Route::post('/products/{product}/deal/payment_intent', [ProductDealController::class, 'createPaymentIntent']);
     Route::post('/products/{product}/deal/payment_intent/verify', [ProductDealController::class, 'verifyPaymentIntent']);
     Route::post('/products/{product}/deal/cancel', [ProductDealController::class, 'cancel']);
+    Route::post('/products/{product}/deal/report_delivery', [ProductDealController::class, 'reportDelivery']);
+    Route::post('/products/{product}/deal/report_receipt', [ProductDealController::class, 'reportReceipt']);
 
 
 });

--- a/routes/easymarket_api.php
+++ b/routes/easymarket_api.php
@@ -42,6 +42,7 @@ Route::middleware(['auth:easymarket_api', 'verified'])->group(function () {
 
     Route::post('/products', [ProductController::class, 'store']);
     Route::post('/products/{product}/deal/payment_intent', [ProductDealController::class, 'createPaymentIntent']);
+    Route::post('/products/{product}/deal/payment_intent/verify', [ProductDealController::class, 'verifyPaymentIntent']);
 
 
 });

--- a/routes/easymarket_api.php
+++ b/routes/easymarket_api.php
@@ -5,7 +5,6 @@ use App\Http\Controllers\easymarket\API\AuthController;
 use App\Http\Controllers\easymarket\API\MeController;
 use App\Http\Controllers\easymarket\API\ProductController;
 use App\Http\Controllers\easymarket\API\ProductDealController;
-use Illuminate\Support\Facades\Log;
 
 
 
@@ -38,6 +37,7 @@ Route::middleware(['auth:easymarket_api', 'verified'])->group(function () {
     Route::get('/me/purchased_products', [MeController::class, 'getPurchasedProducts']);
     Route::get('/me/purchased_products/{product}/deal', [MeController::class, 'getPurchasedProductDeal']);
     Route::get('/me/listed_products', [MeController::class, 'getListedProducts']);
+    Route::get('/me/listed_products/{id}', [MeController::class, 'getListedProductDetail']);
     Route::get('/me/listed_products/{product}/deal', [MeController::class, 'getListedProductDeal']);
 
     Route::post('/products', [ProductController::class, 'store']);

--- a/routes/easymarket_api.php
+++ b/routes/easymarket_api.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\easymarket\API\AuthController;
 use App\Http\Controllers\easymarket\API\MeController;
 use App\Http\Controllers\easymarket\API\ProductController;
+use Illuminate\Support\Facades\Log;
 
 
 
@@ -33,6 +34,10 @@ Route::middleware(['auth:easymarket_api', 'verified'])->group(function () {
 
     Route::get('/me', [MeController::class, 'show']);
     Route::put('/me', [MeController::class, 'update']);
+    Route::get('/me/purchased_products', [MeController::class, 'getPurchasedProducts']);
+    Route::get('/me/purchased_products/{product}/deal', [MeController::class, 'getPurchasedProductDeal']);
+    Route::get('/me/listed_products', [MeController::class, 'getListedProducts']);
+    Route::get('/me/listed_products/{product}/deal', [MeController::class, 'getListedProductDeal']);
 
     Route::post('/products', [ProductController::class, 'store']);
 

--- a/routes/easymarket_api.php
+++ b/routes/easymarket_api.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\easymarket\API\AuthController;
 use App\Http\Controllers\easymarket\API\MeController;
 use App\Http\Controllers\easymarket\API\ProductController;
+use App\Http\Controllers\easymarket\API\ProductDealController;
 use Illuminate\Support\Facades\Log;
 
 
@@ -40,6 +41,7 @@ Route::middleware(['auth:easymarket_api', 'verified'])->group(function () {
     Route::get('/me/listed_products/{product}/deal', [MeController::class, 'getListedProductDeal']);
 
     Route::post('/products', [ProductController::class, 'store']);
+    Route::post('/products/{product}/deal/payment_intent', [ProductDealController::class, 'createPaymentIntent']);
 
 
 });

--- a/routes/easymarket_api.php
+++ b/routes/easymarket_api.php
@@ -43,6 +43,7 @@ Route::middleware(['auth:easymarket_api', 'verified'])->group(function () {
     Route::post('/products', [ProductController::class, 'store']);
     Route::post('/products/{product}/deal/payment_intent', [ProductDealController::class, 'createPaymentIntent']);
     Route::post('/products/{product}/deal/payment_intent/verify', [ProductDealController::class, 'verifyPaymentIntent']);
+    Route::post('/products/{product}/deal/cancel', [ProductDealController::class, 'cancel']);
 
 
 });

--- a/tests/Feature/Controllers/easymarket/API/MeController/GetListedProductDealTest.php
+++ b/tests/Feature/Controllers/easymarket/API/MeController/GetListedProductDealTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\Controllers\easymarket\API\MeListedProductController;
+
+use App\Enums\{DealStatus, DealEventActorType, DealEventEventType};
+use App\Models\{Deal, DealEvent, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class GetListedProductDealTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系
+     */
+    public function test_get_listed_product_deal(): void
+    {
+        $buyer = User::factory()->create();
+        $seller = User::factory()->create();
+        $other = User::factory()->create();
+
+        $product = Product::factory()->create();
+
+        $deal = Deal::factory()->create([
+            'seller_id' => $seller->id, 'buyer_id' => $buyer->id, 'product_id' => $product->id, 'status' => DealStatus::Purchased
+        ]);
+        $dealEvents = DealEvent::factory()->for($deal)->for($seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        $response = $this->actingAs($buyer)->getJson('/easymarket/api/me/listed_products/' . $product->id . '/deal');
+
+        $response->assertStatus(200)
+        ->assertJson(
+            fn (AssertableJson $json) =>
+            $json->where('id', $deal->id)
+                ->where('is_purchasable', false)
+                ->where('seller_info.id', $deal->seller->id)
+                ->where('seller_info.nickname', $deal->seller->nickname)
+                ->where('seller_info.profile_image_url', $deal->seller->present()->profileImageUrl)
+                ->where('seller_info.description', $deal->seller->description)
+                ->where('buyer_shipping_info.id', $deal->buyer->id)
+                ->where('buyer_shipping_info.name', $deal->buyer->name)
+                ->where('buyer_shipping_info.postal_code', $deal->buyer->postal_code)
+                ->where('buyer_shipping_info.address', $deal->buyer->address)
+                ->where('buyer_shipping_info.nickname', $deal->buyer->nickname)
+                ->where('buyer_shipping_info.profile_image_url', $deal->buyer->present()->profileImageUrl)
+                ->where('buyer_shipping_info.description', $deal->buyer->description)
+                ->where('status', $deal->status->value)
+                ->where('deal_events.0.id', $dealEvents[0]->id)
+                ->where('deal_events.0.actor_type', $dealEvents[0]->actor_type->value)
+                ->where('deal_events.0.event_type', $dealEvents[0]->event_type->value)
+        );
+
+    }
+
+    /**
+     * 存在しないIDの時
+     */
+    public function test_get_listed_product_deal_not_found(): void
+    {
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->getJson('/easymarket/api/me/listed_products/0/deal');
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/Controllers/easymarket/API/MeController/GetListedProductsTest.php
+++ b/tests/Feature/Controllers/easymarket/API/MeController/GetListedProductsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Controllers\easymarket\API\MeListedProductController;
+
+use App\Models\{Deal, DealEvent, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class GetListedProductsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系
+     */
+    public function test_get_listed_products(): void
+    {
+        $buyer = User::factory()->create();
+        $seller = User::factory()->create();
+        $other = User::factory()->create();
+
+        $products = Product::factory()->count(3)->create();
+
+        //buyerは商品を出品せず、sellerは2つの商品を出品、otherは1つの商品を出品しているデータを作成
+        $deals = Deal::factory()->count(3)->state(new Sequence(
+            ['seller_id' => $seller->id, 'buyer_id' => $buyer->id, 'product_id' => $products[0]->id, 'status' => 'purchased'],
+            ['seller_id' => $seller->id, 'buyer_id' => null, 'product_id' => $products[1]->id, 'status' => 'listing'],
+            ['seller_id' => $other->id, 'buyer_id' => $buyer->id, 'product_id' => $products[2]->id, 'status' => 'listing']
+        ))->create();
+
+        //buyerがログインしても出品している商品はない
+        $response = $this->actingAs($buyer)->getJson('/easymarket/api/me/listed_products');
+        $response->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json->has('products', 0));
+
+        //sellerがログインしていると出品している商品が2つある
+        $response = $this->actingAs($seller)->getJson('/easymarket/api/me/listed_products');
+        $response->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json->has('products', 2));
+
+        //otherがログインしていると出品している商品が1つある
+        $response = $this->actingAs($other)->getJson('/easymarket/api/me/listed_products');
+        $response->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json->has('products', 1));
+    }
+}

--- a/tests/Feature/Controllers/easymarket/API/MeController/GetPurchasedProductDealTest.php
+++ b/tests/Feature/Controllers/easymarket/API/MeController/GetPurchasedProductDealTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Controllers\easymarket\API\MePurchasedProductController;
+
+use App\Enums\{DealStatus, DealEventActorType, DealEventEventType};
+use App\Models\{Deal, DealEvent, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class GetPurchasedProductDealTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系
+     */
+    public function test_get_purchased_product_deal(): void
+    {
+        $buyer = User::factory()->create();
+        $seller = User::factory()->create();
+        $other = User::factory()->create();
+
+        $product = Product::factory()->create();
+
+        $deal = Deal::factory()->create([
+            'seller_id' => $seller->id, 'buyer_id' => $buyer->id, 'product_id' => $product->id, 'status' => DealStatus::Purchased
+        ]);
+        $dealEvents = DealEvent::factory()->for($deal)->for($seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        $response = $this->actingAs($buyer)->getJson('/easymarket/api/me/purchased_products/' . $product->id . '/deal');
+
+        $response->assertStatus(200)
+        ->assertJson(
+            fn (AssertableJson $json) =>
+            $json->where('id', $deal->id)
+                ->where('is_purchasable', false)
+                ->where('seller_info.id', $deal->seller->id)
+                ->where('seller_info.nickname', $deal->seller->nickname)
+                ->where('seller_info.profile_image_url', $deal->seller->present()->profileImageUrl)
+                ->where('seller_info.description', $deal->seller->description)
+                ->where('buyer_shipping_info.id', $deal->buyer->id)
+                ->where('buyer_shipping_info.name', $deal->buyer->name)
+                ->where('buyer_shipping_info.postal_code', $deal->buyer->postal_code)
+                ->where('buyer_shipping_info.address', $deal->buyer->address)
+                ->where('buyer_shipping_info.nickname', $deal->buyer->nickname)
+                ->where('buyer_shipping_info.profile_image_url', $deal->buyer->present()->profileImageUrl)
+                ->where('buyer_shipping_info.description', $deal->buyer->description)
+                ->where('status', $deal->status->value)
+                ->where('deal_events.0.id', $dealEvents[0]->id)
+                ->where('deal_events.0.actor_type', $dealEvents[0]->actor_type->value)
+                ->where('deal_events.0.event_type', $dealEvents[0]->event_type->value)
+        );
+
+    }
+
+    /**
+     * 存在しないIDの時
+     */
+    public function test_get_purchased_product_deal_not_found(): void
+    {
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->getJson('/easymarket/api/me/purchased_products/0/deal');
+
+        $response->assertStatus(404);
+    }
+}
+

--- a/tests/Feature/Controllers/easymarket/API/MeController/GetPurchasedProductsTest.php
+++ b/tests/Feature/Controllers/easymarket/API/MeController/GetPurchasedProductsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Controllers\easymarket\API\MePurchasredProductController;
+
+use App\Models\{Deal, DealEvent, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class GetPurchasedProductsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系
+     */
+    public function test_get_purchased_products(): void
+    {
+        $buyer = User::factory()->create();
+        $seller = User::factory()->create();
+        $other = User::factory()->create();
+
+        $products = Product::factory()->count(3)->create();
+
+        //buyerは2つの商品を購入、sellerとotherは商品を購入しないデータを作成
+        $deals = Deal::factory()->count(3)->state(new Sequence(
+            ['seller_id' => $seller->id, 'buyer_id' => $buyer->id, 'product_id' => $products[0]->id, 'status' => 'purchased'],
+            ['seller_id' => $seller->id, 'buyer_id' => null, 'product_id' => $products[1]->id, 'status' => 'listing'],
+            ['seller_id' => $other->id, 'buyer_id' => $buyer->id, 'product_id' => $products[2]->id, 'status' => 'listing']
+        ))->create();
+
+        //buyerがログインしていると購入した商品が2つある
+        $response = $this->actingAs($buyer)->getJson('/easymarket/api/me/purchased_products');
+        $response->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json->has('products', 2));
+
+        //sellerがログインしていると購入した商品がない
+        $response = $this->actingAs($seller)->getJson('/easymarket/api/me/purchased_products');
+        $response->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json->has('products', 0));
+
+        //otherがログインしていると購入した商品がない
+        $response = $this->actingAs($other)->getJson('/easymarket/api/me/purchased_products');
+        $response->assertStatus(200)
+            ->assertJson(fn (AssertableJson $json) => $json->has('products', 0));
+    }
+}

--- a/tests/Feature/Controllers/easymarket/API/ProductDealController/CancelListingProductTest.php
+++ b/tests/Feature/Controllers/easymarket/API/ProductDealController/CancelListingProductTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature\Feature\Controllers\easymarket\API\ProductController;
+
+use App\Enums\{DealEventActorType, DealEventEventType, DealStatus};
+use App\Models\{Deal, DealEvent, Image, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class CancelListingProductTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $buyer;
+    protected $seller;
+    protected $other;
+    protected $product;
+    protected $image;
+    protected $deal;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->buyer = User::factory()->create();
+        $this->seller = User::factory()->create();
+        $this->other = User::factory()->create();
+        $this->product = Product::factory()->create();
+        $this->image = Image::factory()->create();
+        $this->product->images()->attach($this->image);
+    }
+
+    /**
+     * 正常系
+     */
+    public function test_cancel_listing_product(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Listing,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->seller)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/cancel');
+        $response->assertStatus(200)
+        ->assertJsonStructure([
+            'id',
+            'is_purchasable',
+            'seller_info' => [
+                'id',
+                'nickname',
+                'profile_image_url',
+                'description',
+            ],
+            'buyer_shipping_info' => [
+                'id',
+                'name',
+                'postal_code',
+                'address',
+                'nickname',
+                'profile_image_url',
+                'description',
+            ],
+            'status',
+            'deal_events' => [
+                '*' => [
+                    'id',
+                    'actor_type',
+                    'event_type',
+                ],
+            ],
+        ]);
+
+        // $deal.statusがcanceledであることを確認
+        $this->assertEquals(DealStatus::Canceled, $deal->refresh()->status);
+        // deal_eventsの件数が2件であることを確認
+        $this->assertEquals(2, $deal->dealEvents()->count());
+        
+    }
+
+    /**
+     * ステータスがlisting以外の場合はエラー
+     */
+    public function test_cancel_listing_product_with_not_listing_status(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Purchased,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        // $deal.statusがpurchasedのままであることを確認
+        $this->assertEquals(DealStatus::Purchased, $deal->status);
+        // deal_eventsの件数が1件のままであることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->seller)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/cancel');
+        $response->assertStatus(400);
+
+        // $deal.statusがpurchasedであることを確認
+        $this->assertEquals(DealStatus::Purchased, $deal->refresh()->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+    }
+
+
+    /**
+     * 出品者でない人がキャンセルしようとした場合は認可エラー
+     */
+    public function test_cancel_listing_product_with_not_seller(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Listing,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->other)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/cancel');
+        $response->assertStatus(403);
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->refresh()->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+    }
+
+}

--- a/tests/Feature/Controllers/easymarket/API/ProductDealController/CreatePaymentIntentTest.php
+++ b/tests/Feature/Controllers/easymarket/API/ProductDealController/CreatePaymentIntentTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Feature\Feature\Controllers\easymarket\API\ProductController;
+
+use App\Enums\{DealEventActorType, DealEventEventType, DealStatus};
+use App\Models\{Deal, DealEvent, Image, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class CreatePaymentIntentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $buyer;
+    protected $seller;
+    protected $other;
+    protected $product;
+    protected $image;
+    protected $deal;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->buyer = User::factory()->create();
+        $this->seller = User::factory()->create();
+        $this->other = User::factory()->create();
+        $this->product = Product::factory()->create();
+        $this->image = Image::factory()->create();
+        $this->product->images()->attach($this->image);
+    }
+
+    /**
+     * 正常系
+     */
+    public function test_create_payment_intent(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Listing,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->buyer)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/payment_intent');
+        $response->assertStatus(200)
+        ->assertJson(
+            fn (AssertableJson $json) =>
+            $json->whereType('client_secret', 'string')
+        );
+
+        // $deal.statusがlistingのままであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->refresh()->status);
+        // deal_eventsの件数が1件のままであることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+    }
+
+    /**
+     * ステータスがlisting以外の場合はエラー
+     */
+    public function test_create_payment_intent_with_not_listing_status(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Purchased,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(2)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+            ['actor_type' => DealEventActorType::Buyer, 'event_type' => DealEventEventType::Purchase],
+        ))->create();
+
+        // $deal.statusがpurchasedであることを確認
+        $this->assertEquals(DealStatus::Purchased, $deal->status);
+        // deal_eventsの件数が2件であることを確認
+        $this->assertEquals(2, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->buyer)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/payment_intent');
+        $response->assertStatus(400);
+
+        // $deal.statusがpurchasedのままであることを確認
+        $this->assertEquals(DealStatus::Purchased, $deal->refresh()->status);
+        // deal_eventsの件数が2件のままであることを確認
+        $this->assertEquals(2, $deal->dealEvents()->count());
+    }
+
+    /**
+     * 購入者の氏名、郵便番号、住所が未登録の場合は購入できない
+     */
+    public function test_create_payment_intent_with_not_registered_shipping_info(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Listing,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+
+        $this->buyer->name = '';
+        $this->buyer->postal_code = '';
+        $this->buyer->address = '';
+        $this->buyer->save();
+
+        $response = $this->actingAs($this->buyer)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/payment_intent');
+        $response->assertStatus(400);
+
+        // $deal.statusがlistingのままであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->refresh()->status);
+        // deal_eventsの件数が1件のままであることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+    }
+        
+
+    /**
+     * 出品者が購入しようとした場合は認可エラー
+     */
+    public function test_create_payment_intent_with_seller(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Listing,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->seller)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/payment_intent');
+        $response->assertStatus(403);
+
+        // $deal.statusがlistingのままであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->refresh()->status);
+        // deal_eventsの件数が1件のままであることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+    }
+
+}

--- a/tests/Feature/Controllers/easymarket/API/ProductDealController/ReportDeliveryDealTest.php
+++ b/tests/Feature/Controllers/easymarket/API/ProductDealController/ReportDeliveryDealTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature\Feature\Controllers\easymarket\API\ProductController;
+
+use App\Enums\{DealEventActorType, DealEventEventType, DealStatus};
+use App\Models\{Deal, DealEvent, Image, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReportDeliveryDealTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $buyer;
+    protected $seller;
+    protected $other;
+    protected $product;
+    protected $image;
+    protected $deal;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->buyer = User::factory()->create();
+        $this->seller = User::factory()->create();
+        $this->other = User::factory()->create();
+        $this->product = Product::factory()->create();
+        $this->image = Image::factory()->create();
+        $this->product->images()->attach($this->image);
+    }
+
+    /**
+     * 正常系
+     */
+    public function test_report_delivery_deal(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->buyer, 'buyer')->for($this->product, 'product')->create([
+            'status' => DealStatus::Purchased,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(2)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+            ['actor_type' => DealEventActorType::Buyer, 'event_type' => DealEventEventType::Purchase],
+        ))->create();
+
+        // $deal.statusがpurchasedであることを確認
+        $this->assertEquals(DealStatus::Purchased, $deal->status);
+        // deal_eventsの件数が2件であることを確認
+        $this->assertEquals(2, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->seller)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/report_delivery');
+        $response->assertStatus(200)
+        ->assertJsonStructure([
+            'id',
+            'is_purchasable',
+            'seller_info' => [
+                'id',
+                'nickname',
+                'profile_image_url',
+                'description',
+            ],
+            'buyer_shipping_info' => [
+                'id',
+                'name',
+                'postal_code',
+                'address',
+                'nickname',
+                'profile_image_url',
+                'description',
+            ],
+            'status',
+            'deal_events' => [
+                '*' => [
+                    'id',
+                    'actor_type',
+                    'event_type',
+                ],
+            ],
+        ]);
+
+        // $deal.statusがshippingであることを確認
+        $this->assertEquals(DealStatus::Shipping, $deal->refresh()->status);
+        // deal_eventsの件数が3件であることを確認
+        $this->assertEquals(3, $deal->dealEvents()->count());
+        
+    }
+
+    /**
+     * ステータスがpurchased以外の場合はエラー
+     */
+    public function test_report_delivery_deal_with_not_purchased_status(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Listing,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->seller)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/report_delivery');
+        $response->assertStatus(400);
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->refresh()->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+    }
+
+
+    /**
+     * 出品者でない人が配送報告しようとした場合は認可エラー
+     */
+    public function test_report_delivery_deal_with_not_seller(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->buyer, 'buyer')->for($this->product, 'product')->create([
+            'status' => DealStatus::Purchased,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(2)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+            ['actor_type' => DealEventActorType::Buyer, 'event_type' => DealEventEventType::Purchase],
+        ))->create();
+
+        // $deal.statusがpurchasedであることを確認
+        $this->assertEquals(DealStatus::Purchased, $deal->status);
+        // deal_eventsの件数が2件であることを確認
+        $this->assertEquals(2, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->other)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/report_delivery');
+        $response->assertStatus(403);
+
+        // $deal.statusがpurchasedであることを確認
+        $this->assertEquals(DealStatus::Purchased, $deal->refresh()->status);
+        // deal_eventsの件数が2件であることを確認
+        $this->assertEquals(2, $deal->dealEvents()->count());
+    }
+
+}

--- a/tests/Feature/Controllers/easymarket/API/ProductDealController/ReportReceiptDealTest.php
+++ b/tests/Feature/Controllers/easymarket/API/ProductDealController/ReportReceiptDealTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\Feature\Controllers\easymarket\API\ProductController;
+
+use App\Enums\{DealEventActorType, DealEventEventType, DealStatus};
+use App\Models\{Deal, DealEvent, Image, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReportReceiptDealTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $buyer;
+    protected $seller;
+    protected $other;
+    protected $product;
+    protected $image;
+    protected $deal;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->buyer = User::factory()->create();
+        $this->seller = User::factory()->create();
+        $this->other = User::factory()->create();
+        $this->product = Product::factory()->create();
+        $this->image = Image::factory()->create();
+        $this->product->images()->attach($this->image);
+    }
+
+    /**
+     * 正常系
+     */
+    public function test_report_receipt_deal(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->buyer, 'buyer')->for($this->product, 'product')->create([
+            'status' => DealStatus::Shipping,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(3)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+            ['actor_type' => DealEventActorType::Buyer, 'event_type' => DealEventEventType::Purchase],
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::ReportDelivery],
+        ))->create();
+
+        // $deal.statusがshippingであることを確認
+        $this->assertEquals(DealStatus::Shipping, $deal->status);
+        // deal_eventsの件数が3件であることを確認
+        $this->assertEquals(3, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->buyer)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/report_receipt');
+        $response->assertStatus(200)
+        ->assertJsonStructure([
+            'id',
+            'is_purchasable',
+            'seller_info' => [
+                'id',
+                'nickname',
+                'profile_image_url',
+                'description',
+            ],
+            'buyer_shipping_info' => [
+                'id',
+                'name',
+                'postal_code',
+                'address',
+                'nickname',
+                'profile_image_url',
+                'description',
+            ],
+            'status',
+            'deal_events' => [
+                '*' => [
+                    'id',
+                    'actor_type',
+                    'event_type',
+                ],
+            ],
+        ]);
+
+        // $deal.statusがcompletedであることを確認
+        $this->assertEquals(DealStatus::Completed, $deal->refresh()->status);
+        // deal_eventsの件数が4件であることを確認
+        $this->assertEquals(4, $deal->dealEvents()->count());
+        
+    }
+
+    /**
+     * ステータスがshipping以外の場合はエラー
+     */
+    public function test_report_receipt_deal_with_invalid_status(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->buyer, 'buyer')->for($this->product, 'product')->create([
+            'status' => DealStatus::Completed,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(4)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+            ['actor_type' => DealEventActorType::Buyer, 'event_type' => DealEventEventType::Purchase],
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::ReportDelivery],
+            ['actor_type' => DealEventActorType::Buyer, 'event_type' => DealEventEventType::ReportReceipt],
+        ))->create();
+
+        // $deal.statusがcompletedであることを確認
+        $this->assertEquals(DealStatus::Completed, $deal->status);
+        // deal_eventsの件数が4件であることを確認
+        $this->assertEquals(4, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->buyer)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/report_receipt');
+        $response->assertStatus(400);
+
+        // $deal.statusがcompletedであることを確認
+        $this->assertEquals(DealStatus::Completed, $deal->refresh()->status);
+        // deal_eventsの件数が4件のままであることを確認
+        $this->assertEquals(4, $deal->dealEvents()->count());
+        
+    }
+
+
+    /**
+     * 購入者でない人が受取報告しようとした場合は認可エラー
+     */
+    public function test_report_receipt_deal_with_invalid_buyer(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->buyer, 'buyer')->for($this->product, 'product')->create([
+            'status' => DealStatus::Shipping,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(3)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+            ['actor_type' => DealEventActorType::Buyer, 'event_type' => DealEventEventType::Purchase],
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::ReportDelivery],
+        ))->create();
+
+        // $deal.statusがshippingであることを確認
+        $this->assertEquals(DealStatus::Shipping, $deal->status);
+        // deal_eventsの件数が3件であることを確認
+        $this->assertEquals(3, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->other)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/report_receipt');
+        $response->assertStatus(403);
+
+        // $deal.statusがshippingであることを確認
+        $this->assertEquals(DealStatus::Shipping, $deal->status);
+        // deal_eventsの件数が3件のままであることを確認
+        $this->assertEquals(3, $deal->dealEvents()->count());
+        
+    }
+
+}

--- a/tests/Feature/Controllers/easymarket/API/ProductDealController/VerifyPaymentIntentTest.php
+++ b/tests/Feature/Controllers/easymarket/API/ProductDealController/VerifyPaymentIntentTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Feature\Feature\Controllers\easymarket\API\ProductController;
+
+use App\Enums\{DealEventActorType, DealEventEventType, DealStatus};
+use App\Models\{Deal, DealEvent, Image, Product, User};
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class VerifyPaymentIntentTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    protected $buyer;
+    protected $seller;
+    protected $other;
+    protected $product;
+    protected $image;
+    protected $deal;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->buyer = User::factory()->create();
+        $this->seller = User::factory()->create();
+        $this->other = User::factory()->create();
+        $this->product = Product::factory()->create();
+        $this->image = Image::factory()->create();
+        $this->product->images()->attach($this->image);
+    }
+
+    /**
+     * 正常系
+     */
+    public function test_verify_payment_intent(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Listing,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->buyer)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/payment_intent/verify', [
+            'payment_intent_id' => $this->faker->text(20),
+        ]);
+        $response->assertStatus(200)
+        ->assertJsonStructure([
+            'id',
+            'is_purchasable',
+            'seller_info' => [
+                'id',
+                'nickname',
+                'profile_image_url',
+                'description',
+            ],
+            'buyer_shipping_info' => [
+                'id',
+                'name',
+                'postal_code',
+                'address',
+                'nickname',
+                'profile_image_url',
+                'description',
+            ],
+            'status',
+            'deal_events' => [
+                '*' => [
+                    'id',
+                    'actor_type',
+                    'event_type',
+                ],
+            ],
+        ]);
+
+        // $deal.statusがpurchasedであることを確認
+        $this->assertEquals(DealStatus::Purchased, $deal->refresh()->status);
+        // deal_eventsの件数が2件であることを確認
+        $this->assertEquals(2, $deal->dealEvents()->count());
+    }
+
+    /**
+     * ステータスがlisting以外の場合はエラー
+     */
+    public function test_verify_payment_intent_with_not_listing_status(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Purchased,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(2)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+            ['actor_type' => DealEventActorType::Buyer, 'event_type' => DealEventEventType::Purchase],
+        ))->create();
+
+        // $deal.statusがpurchasedであることを確認
+        $this->assertEquals(DealStatus::Purchased, $deal->status);
+        // deal_eventsの件数が2件であることを確認
+        $this->assertEquals(2, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->buyer)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/payment_intent/verify', [
+            'payment_intent_id' => $this->faker->text(20),
+        ]);
+        $response->assertStatus(400);
+
+        // $deal.statusがpurchasedのままであることを確認
+        $this->assertEquals(DealStatus::Purchased, $deal->refresh()->status);
+        // deal_eventsの件数が2件のままであることを確認
+        $this->assertEquals(2, $deal->dealEvents()->count());
+    }
+
+    /**
+     * 購入者の氏名、郵便番号、住所が未登録の場合は購入できない
+     */
+    public function test_verify_payment_intent_with_not_registered_shipping_info(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Listing,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+
+        $this->buyer->name = '';
+        $this->buyer->postal_code = '';
+        $this->buyer->address = '';
+        $this->buyer->save();
+
+        $response = $this->actingAs($this->buyer)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/payment_intent/verify', [
+            'payment_intent_id' => $this->faker->text(20),
+        ]);
+        $response->assertStatus(400);
+
+        // $deal.statusがlistingのままであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->refresh()->status);
+        // deal_eventsの件数が1件のままであることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+    }
+        
+
+    /**
+     * 出品者が購入しようとした場合は認可エラー
+     */
+    public function test_verify_payment_intent_with_seller(): void
+    {
+        $deal = Deal::factory()->for($this->seller, 'seller')->for($this->product, 'product')->create([
+            'status' => DealStatus::Listing,
+        ]);
+        DealEvent::factory()->for($deal)->for($this->seller, 'deal_eventable')->count(1)->state(new Sequence(
+            ['actor_type' => DealEventActorType::Seller, 'event_type' => DealEventEventType::Listing],
+        ))->create();
+
+        // $deal.statusがlistingであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->status);
+        // deal_eventsの件数が1件であることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+
+        $response = $this->actingAs($this->seller)->postJson('/easymarket/api/products/' . $deal->product_id . '/deal/payment_intent/verify', [
+            'payment_intent_id' => $this->faker->text(20),
+        ]);
+        $response->assertStatus(403);
+
+        // $deal.statusがlistingのままであることを確認
+        $this->assertEquals(DealStatus::Listing, $deal->refresh()->status);
+        // deal_eventsの件数が1件のままであることを確認
+        $this->assertEquals(1, $deal->dealEvents()->count());
+    }
+
+}


### PR DESCRIPTION
# 作成したAPI
Stripeの商品支払いインテント作成APIと商品支払いインテント確認API実装
　Stiripeサーバーにアクセスしないよう、StirpeServiceMockを作成
　.envの環境で分岐をかけて、ローカル環境ではMockを使用するよう実装

出品キャンセルAPI、配送報告API・受取報告API実装
　商品ステータスが出品中の商品でないとキャンセルできない
　出品者以外がこのAPIを叩いても403エラーが発生する
　成功するとdeal_eventsのstatusがcanceledになる